### PR TITLE
perf: reduce promise pool wake overhead

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 export class PromisePool<T = unknown> {
   private readonly promises: Set<Promise<T>>;
-  private waitingPromise: Promise<void> | undefined;
-  private resumeFunction: (() => void) | undefined;
+  private readonly resumeFunctions: Array<() => void>;
+  private resumeFunctionIndex: number;
+  private reservedPromiseCount: number;
   private _concurrency: number;
   private _queuedPromiseCount: number;
 
@@ -9,6 +10,9 @@ export class PromisePool<T = unknown> {
     this._concurrency = concurrency;
     this._queuedPromiseCount = 0;
     this.promises = new Set();
+    this.resumeFunctions = [];
+    this.resumeFunctionIndex = 0;
+    this.reservedPromiseCount = 0;
   }
 
   get workingPromiseCount(): number {
@@ -32,17 +36,11 @@ export class PromisePool<T = unknown> {
   }
 
   promiseAll(): Promise<T[]> {
-    return Promise.all(this.promises.values());
+    return Promise.all(this.promises);
   }
 
   promiseAllSettled(): Promise<PromiseSettledResult<T>[]> {
-    return Promise.all(
-      [...this.promises.values()].map((promise: Promise<T>) =>
-        promise
-          .then((value) => ({ status: 'fulfilled', value }) as PromiseFulfilledResult<T>)
-          .catch((error: unknown) => ({ status: 'rejected', reason: error }) as PromiseRejectedResult)
-      )
-    );
+    return Promise.allSettled(this.promises);
   }
 
   async run(startPromise: () => Promise<T>): Promise<void> {
@@ -57,27 +55,56 @@ export class PromisePool<T = unknown> {
 
   private async privateRunAndWaitForReturnValue<R extends T>(startPromise: () => Promise<R>): Promise<[Promise<R>]> {
     this._queuedPromiseCount++;
-    while (this.promises.size >= this._concurrency) {
-      this.waitingPromise ??= new Promise<void>((resolve) => {
-        this.resumeFunction = resolve;
+    await this.waitForCapacity();
+
+    let promise: Promise<R>;
+    try {
+      promise = startPromise().finally(() => {
+        this._queuedPromiseCount--;
+        this.promises.delete(promise);
+        this.resume();
       });
-      await this.waitingPromise;
-    }
-    const promise = startPromise().finally(() => {
+    } catch (error) {
       this._queuedPromiseCount--;
-      this.promises.delete(promise);
+      this.reservedPromiseCount--;
       this.resume();
-    });
+      throw error;
+    }
+
+    this.reservedPromiseCount--;
     this.promises.add(promise);
     // Don't return the promise as is since run() wants to ignore the return value.
     return [promise];
   }
 
-  private resume(): void {
-    if (!this.resumeFunction) return;
+  private async waitForCapacity(): Promise<void> {
+    if (this.hasCapacity()) {
+      this.reservedPromiseCount++;
+      return;
+    }
 
-    this.resumeFunction();
-    this.waitingPromise = undefined;
-    this.resumeFunction = undefined;
+    await new Promise<void>((resolve) => {
+      this.resumeFunctions.push(resolve);
+    });
+  }
+
+  private resume(): void {
+    while (this.hasCapacity()) {
+      const resumeFunction = this.resumeFunctions[this.resumeFunctionIndex];
+      if (!resumeFunction) break;
+
+      this.resumeFunctionIndex++;
+      this.reservedPromiseCount++;
+      resumeFunction();
+    }
+
+    if (this.resumeFunctionIndex === this.resumeFunctions.length) {
+      this.resumeFunctions.length = 0;
+      this.resumeFunctionIndex = 0;
+    }
+  }
+
+  private hasCapacity(): boolean {
+    return this.promises.size + this.reservedPromiseCount < this._concurrency;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,14 +78,19 @@ export class PromisePool<T = unknown> {
   }
 
   private async waitForCapacity(): Promise<void> {
-    if (this.hasCapacity()) {
-      this.reservedPromiseCount++;
-      return;
+    while (!this.hasCapacity()) {
+      await new Promise<void>((resolve) => {
+        this.resumeFunctions.push(resolve);
+      });
+
+      if (this.promises.size + this.reservedPromiseCount <= this._concurrency) {
+        return;
+      }
+
+      this.reservedPromiseCount--;
     }
 
-    await new Promise<void>((resolve) => {
-      this.resumeFunctions.push(resolve);
-    });
+    this.reservedPromiseCount++;
   }
 
   private resume(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 export class PromisePool<T = unknown> {
   private readonly promises: Set<Promise<T>>;
-  private readonly resumeFunctions: Array<() => void>;
+  private readonly resumeFunctions: Array<(() => void) | undefined>;
   private resumeFunctionIndex: number;
   private reservedPromiseCount: number;
   private _concurrency: number;
@@ -90,16 +90,21 @@ export class PromisePool<T = unknown> {
 
   private resume(): void {
     while (this.hasCapacity()) {
-      const resumeFunction = this.resumeFunctions[this.resumeFunctionIndex];
+      const resumeFunctionIndex = this.resumeFunctionIndex;
+      const resumeFunction = this.resumeFunctions[resumeFunctionIndex];
       if (!resumeFunction) break;
 
       this.resumeFunctionIndex++;
+      this.resumeFunctions[resumeFunctionIndex] = undefined;
       this.reservedPromiseCount++;
       resumeFunction();
     }
 
     if (this.resumeFunctionIndex === this.resumeFunctions.length) {
       this.resumeFunctions.length = 0;
+      this.resumeFunctionIndex = 0;
+    } else if (this.resumeFunctionIndex >= 256 && this.resumeFunctionIndex >= this.resumeFunctions.length / 2) {
+      this.resumeFunctions.splice(0, this.resumeFunctionIndex);
       this.resumeFunctionIndex = 0;
     }
   }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -143,6 +143,48 @@ test('increase concurrency during task', async () => {
   expect(env.finishedCount).toBe(3);
 });
 
+test('increase concurrency starts one queued task per newly available slot', async () => {
+  const env = new TestEnvironment(1);
+
+  const [resolve1] = await env.runTask();
+  const promise2 = env.runTask();
+  const promise3 = env.runTask();
+
+  await waitForMicrotasks();
+  expect(env.startedCount).toBe(1);
+
+  env.promisePool.concurrency = 3;
+  const [[resolve2], [resolve3]] = await Promise.all([promise2, promise3]);
+
+  expect(env.startedCount).toBe(3);
+  expect(env.finishedCount).toBe(0);
+
+  resolve1();
+  resolve2();
+  resolve3();
+  await env.promisePool.promiseAll();
+
+  expect(env.finishedCount).toBe(3);
+});
+
+test('run releases queue count and capacity when startPromise throws', async () => {
+  const env = new TestEnvironment(1);
+
+  await expect(
+    env.promisePool.run(() => {
+      throw new Error('start failed');
+    })
+  ).rejects.toThrow('start failed');
+  expect(env.promisePool.queuedPromiseCount).toBe(0);
+
+  const [resolve] = await env.runTask();
+  expect(env.startedCount).toBe(1);
+
+  resolve();
+  await env.promisePool.promiseAll();
+  expect(env.finishedCount).toBe(1);
+});
+
 test('promiseAll() returns a rejected promise immediately after one of promises is rejected', async () => {
   const env = new TestEnvironment(2);
 
@@ -257,4 +299,9 @@ class TestEnvironment {
 
 async function sleep(milliseconds: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+async function waitForMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
 }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -167,6 +167,37 @@ test('increase concurrency starts one queued task per newly available slot', asy
   expect(env.finishedCount).toBe(3);
 });
 
+test('decrease concurrency cancels stale reservations before queued tasks start', async () => {
+  const env = new TestEnvironment(1);
+
+  const [resolve1] = await env.runTask();
+  const promise2 = env.runTask();
+  const promise3 = env.runTask();
+
+  await waitForMicrotasks();
+  env.promisePool.concurrency = 3;
+  env.promisePool.concurrency = 1;
+  await waitForMicrotasks();
+
+  expect(env.startedCount).toBe(1);
+  expect(env.promisePool.workingPromiseCount).toBe(1);
+
+  resolve1();
+  const [resolve2] = await promise2;
+  await waitForMicrotasks();
+
+  expect(env.startedCount).toBe(2);
+  expect(env.promisePool.workingPromiseCount).toBe(1);
+
+  resolve2();
+  const [resolve3] = await promise3;
+  resolve3();
+  await env.promisePool.promiseAll();
+
+  expect(env.startedCount).toBe(3);
+  expect(env.finishedCount).toBe(3);
+});
+
 test('run releases queue count and capacity when startPromise throws', async () => {
   const env = new TestEnvironment(1);
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -185,6 +185,46 @@ test('run releases queue count and capacity when startPromise throws', async () 
   expect(env.finishedCount).toBe(1);
 });
 
+test('run compacts consumed waiter queue slots under sustained load', async () => {
+  const env = new TestEnvironment(1);
+  const [resolveFirst] = await env.runTask();
+  const runningResolves = [resolveFirst];
+  const pendingTasks = [env.runTask(), env.runTask()];
+
+  await waitForMicrotasks();
+  for (let i = 0; i < 512; i++) {
+    const resolve = runningResolves.shift();
+    if (!resolve) throw new Error('running task should exist');
+
+    resolve();
+    const pendingTask = pendingTasks.shift();
+    if (!pendingTask) throw new Error('pending task should exist');
+
+    const [resolveNext] = await pendingTask;
+    runningResolves.push(resolveNext);
+    pendingTasks.push(env.runTask());
+  }
+
+  await waitForMicrotasks();
+  const internals = env.promisePool as unknown as PromisePoolInternals;
+  expect(internals.resumeFunctions.length).toBeLessThan(300);
+  expect(internals.resumeFunctionIndex).toBeLessThan(300);
+
+  while (pendingTasks.length > 0) {
+    const resolveRunning = runningResolves.shift();
+    const pendingTask = pendingTasks.shift();
+    if (!resolveRunning || !pendingTask) throw new Error('task should exist');
+
+    resolveRunning();
+    const [resolve] = await pendingTask;
+    runningResolves.push(resolve);
+  }
+  for (const resolve of runningResolves) {
+    resolve();
+  }
+  await env.promisePool.promiseAll();
+});
+
 test('promiseAll() returns a rejected promise immediately after one of promises is rejected', async () => {
   const env = new TestEnvironment(2);
 
@@ -269,6 +309,10 @@ test('runAndWaitForReturnValue returns the resolved value of a promise', async (
 
 type ResolveFunction = (value?: unknown) => void;
 type RejectFunction = (reason?: unknown) => void;
+interface PromisePoolInternals {
+  resumeFunctions: unknown[];
+  resumeFunctionIndex: number;
+}
 
 class TestEnvironment {
   promisePool: PromisePool;


### PR DESCRIPTION
## Summary
- replace shared waiting promise with FIFO per-waiter resolvers and reserved capacity tracking
- use native Promise.allSettled() directly over the active promise set
- add tests for multi-slot concurrency increases and synchronous start failures

## Verification
- yarn test
- yarn check-all-for-ai