### PR TITLE
perf: start tasks synchronously when the pool has capacity

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+// Shared by all fast-path run() calls to avoid allocating a new promise per call.
+const RESOLVED_PROMISE = Promise.resolve();
+
 export class PromisePool<T = unknown> {
   private readonly promises: Set<Promise<T>>;
   private readonly resumeFunctions: Array<(() => void) | undefined>;
@@ -43,54 +46,112 @@ export class PromisePool<T = unknown> {
     return Promise.allSettled(this.promises);
   }
 
-  async run(startPromise: () => Promise<T>): Promise<void> {
-    // eslint-disable-next-line @typescript-eslint/no-floating-promises
-    await this.privateRunAndWaitForReturnValue(startPromise);
-  }
-
-  async runAndWaitForReturnValue<R extends T>(startPromise: () => Promise<R>): Promise<R> {
-    const [promise] = await this.privateRunAndWaitForReturnValue(startPromise);
-    return await promise;
-  }
-
-  private async privateRunAndWaitForReturnValue<R extends T>(startPromise: () => Promise<R>): Promise<[Promise<R>]> {
+  run(startPromise: () => Promise<T>): Promise<void> {
     this._queuedPromiseCount++;
-    await this.waitForCapacity();
+    // Start the task synchronously when the pool has capacity to avoid the
+    // promise allocations and microtask hops of the queued (slow) path.
+    if (this.tryReserveCapacity()) {
+      try {
+        void this.startReservedTask(startPromise);
+      } catch (error) {
+        return Promise.reject(error);
+      }
+      return RESOLVED_PROMISE;
+    }
+    return this.runQueued(startPromise);
+  }
 
+  runAndWaitForReturnValue<R extends T>(startPromise: () => Promise<R>): Promise<R> {
+    this._queuedPromiseCount++;
+    if (this.tryReserveCapacity()) {
+      try {
+        return this.startReservedTask(startPromise);
+      } catch (error) {
+        return Promise.reject(error);
+      }
+    }
+    return this.runQueuedAndWaitForReturnValue(startPromise);
+  }
+
+  private async runQueued(startPromise: () => Promise<T>): Promise<void> {
+    while (!this.tryReserveCapacity()) {
+      await this.waitForResume();
+      if (this.tryKeepReservedSlot()) break;
+    }
+    // The started promise is intentionally discarded since run() resolves once the task starts.
+    void this.startReservedTask(startPromise);
+  }
+
+  private async runQueuedAndWaitForReturnValue<R extends T>(startPromise: () => Promise<R>): Promise<R> {
+    while (!this.tryReserveCapacity()) {
+      await this.waitForResume();
+      if (this.tryKeepReservedSlot()) break;
+    }
+    // The async function awaits the returned promise, so the caller receives the task's resolved value.
+    return this.startReservedTask(startPromise);
+  }
+
+  /**
+   * Starts the given task using a slot the caller has already reserved.
+   * The reservation is converted into a working promise, or released if `startPromise` throws.
+   */
+  private startReservedTask<R extends T>(startPromise: () => Promise<R>): Promise<R> {
     let promise: Promise<R>;
     try {
-      promise = startPromise().finally(() => {
-        this._queuedPromiseCount--;
-        this.promises.delete(promise);
-        this.resume();
-      });
+      // Use `.then()` with two handlers instead of `.finally()` since `.finally()` allocates extra internal promises.
+      promise = startPromise().then(
+        (value) => {
+          this.completeTask(promise);
+          return value;
+        },
+        (error: unknown) => {
+          this.completeTask(promise);
+          throw error;
+        }
+      );
     } catch (error) {
       this._queuedPromiseCount--;
       this.reservedPromiseCount--;
       this.resume();
       throw error;
     }
-
     this.reservedPromiseCount--;
     this.promises.add(promise);
-    // Don't return the promise as is since run() wants to ignore the return value.
-    return [promise];
+    return promise;
   }
 
-  private async waitForCapacity(): Promise<void> {
-    while (!this.hasCapacity()) {
-      await new Promise<void>((resolve) => {
-        this.resumeFunctions.push(resolve);
-      });
-
-      if (this.promises.size + this.reservedPromiseCount <= this._concurrency) {
-        return;
-      }
-
-      this.reservedPromiseCount--;
+  private tryReserveCapacity(): boolean {
+    if (this.promises.size + this.reservedPromiseCount >= this._concurrency) {
+      return false;
     }
-
     this.reservedPromiseCount++;
+    return true;
+  }
+
+  // This is not an async function so that awaiting it costs no extra promise beyond the waiter itself.
+  private waitForResume(): Promise<void> {
+    return new Promise<void>((resolve) => {
+      this.resumeFunctions.push(resolve);
+    });
+  }
+
+  /**
+   * Decides whether the slot reserved by resume() can be kept, releasing it otherwise.
+   * The check happens after a microtask hop so that a concurrency reduction applied
+   * right after resume() can still cancel stale reservations.
+   */
+  private tryKeepReservedSlot(): boolean {
+    if (this.promises.size + this.reservedPromiseCount <= this._concurrency) {
+      return true;
+    }
+    this.reservedPromiseCount--;
+    return false;
+  }
+
+  private completeTask(promise: Promise<T>): void {
+    this._queuedPromiseCount--;
+    this.promises.delete(promise);
+    this.resume();
   }
 
   private resume(): void {


### PR DESCRIPTION
## Customer Summary

- Running tasks through `PromisePool` is now roughly 2x–2.5x faster, with no changes to the public API or observable behavior.
- Applications that push many small tasks through a pool (e.g. batched API calls or file operations) see lower overhead per task.
- No migration is needed; existing code keeps working as-is.

## Technical Summary

- `run()` and `runAndWaitForReturnValue()` now start tasks synchronously when the pool has free capacity, instead of always passing through two nested async functions (`privateRunAndWaitForReturnValue` → `waitForCapacity`). On this fast path, `run()` returns a shared pre-resolved promise, so no promise is allocated per call.
- The queued (saturated) path awaits the raw waiter promise directly via small non-async helpers (`tryReserveCapacity`, `waitForResume`, `tryKeepReservedSlot`), eliminating the intermediate `waitForCapacity` async-function promise and the tuple-unwrapping hop per queued task.
- Task completion is tracked with a two-handler `.then()` instead of `.finally()`, which allocates extra internal promises.
- The waiter-queue machinery (`resumeFunctions`, index-based dequeue with compaction) and the reservation-recheck semantics on concurrency reduction are unchanged, so scheduling behavior (FIFO wake-up, stale-reservation cancellation) is preserved.

## Why

- Every `run()` call paid the cost of several promise allocations and microtask hops even when the pool had free capacity, which dominated the library's overhead for short tasks.
- Restructuring the hot path to be synchronous keeps the existing waiter-queue design and semantics while removing per-task allocations; benchmarks (200k tasks, Node.js 24, median of 7 runs):
  - Capacity available: 56.2ms → 26.7ms (2.1x faster)
  - Saturated (queued): 224.1ms → 99.8ms (2.2x faster)
  - `runAndWaitForReturnValue`: 63.3ms → 25.4ms (2.5x faster)

## Testing

- `yarn vitest run` (all 13 existing tests pass)
- `yarn verify` (type checking with tsgo and oxlint pass with no warnings)
- Benchmarked old vs. new implementation with a standalone script covering the fast path, the saturated path, and `runAndWaitForReturnValue`
