### PR TITLE
docs: refine README with features, API reference, and accurate examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,14 @@ Creates a pool that runs at most `concurrency` tasks concurrently.
 
 ### Error handling
 
-A rejection from a task passed to `run()` is not reported through `run()`'s returned promise (which only signals that the task started).
-Use `runAndWaitForReturnValue()` to receive rejections directly, or `promiseAllSettled()` to collect them in bulk.
+A rejection from a task passed to `run()` is not reported through `run()`'s returned promise (which only signals that the task started), and it becomes an unhandled promise rejection unless something else observes it.
+`promiseAll()` and `promiseAllSettled()` cover only the tasks still running at the moment of the call — a task that has already settled is removed from the pool, so a later call cannot collect its rejection.
+
+When you need task outcomes reliably, use `runAndWaitForReturnValue()` and collect the returned promises yourself:
+
+```ts
+const outcomes = await Promise.allSettled(tasks.map((task) => promisePool.runAndWaitForReturnValue(task)));
+```
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -1,47 +1,132 @@
 # minimal-promise-pool
 
 [![Test](https://github.com/WillBooster/minimal-promise-pool/actions/workflows/test.yml/badge.svg)](https://github.com/WillBooster/minimal-promise-pool/actions/workflows/test.yml)
+[![npm version](https://img.shields.io/npm/v/minimal-promise-pool.svg)](https://www.npmjs.com/package/minimal-promise-pool)
+[![license](https://img.shields.io/npm/l/minimal-promise-pool.svg)](https://github.com/WillBooster/minimal-promise-pool/blob/main/LICENSE)
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release)
 
-A minimal library for managing the maximum number of promise instances.
-For example, `new PromisePool(2)` limits the maximum number of concurrent executions to two.
+A minimal, zero-dependency promise pool for limiting the number of concurrently running promises.
+For example, `new PromisePool(2)` runs at most two tasks at the same time and queues the rest.
 
-## How to Use
+## Features
 
-The following example code runs only two promises at a maximum.
+- **Minimal** — a single class with no runtime dependencies.
+- **Typed** — written in TypeScript with full type definitions.
+- **Dual package** — ships both ESM and CommonJS builds.
+- **FIFO scheduling** — queued tasks start in the order they were submitted.
+- **Adjustable concurrency** — change the limit at runtime; the pool adapts immediately.
 
-```ts
-import { PromisePool, sleep } from 'minimal-promise-pool';
+## Installation
 
-(async () => {
-  const promisePool = new PromisePool(2);
-  await promisePool.run(async () => {
-    console.log('First task started');
-    await sleep(10 * 1000);
-    console.log('First task finished');
-  });
-  await promisePool.run(async () => {
-    console.log('Second task started');
-    await sleep(10 * 1000);
-    console.log('Second task finished');
-  });
-  await promisePool.run(async () => {
-    console.log('Third task started');
-    await sleep(10 * 1000);
-    console.log('Third task finished');
-  });
-})();
+```sh
+npm install minimal-promise-pool
+# or
+yarn add minimal-promise-pool
 ```
 
-The result is as follows:
+## Quick Start
+
+The following example runs at most two tasks concurrently:
+
+```ts
+import { PromisePool } from 'minimal-promise-pool';
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const promisePool = new PromisePool(2);
+await promisePool.run(async () => {
+  console.log('First task started');
+  await sleep(10_000);
+  console.log('First task finished');
+});
+await promisePool.run(async () => {
+  console.log('Second task started');
+  await sleep(10_000);
+  console.log('Second task finished');
+});
+await promisePool.run(async () => {
+  console.log('Third task started');
+  await sleep(10_000);
+  console.log('Third task finished');
+});
+```
+
+Output:
 
 ```
 First task started
 Second task started
-# Wait for about 10 seconds
+# ... about 10 seconds ...
 First task finished
 Third task started
 Second task finished
-# Wait for about 10 seconds
+# ... about 10 seconds ...
 Third task finished
 ```
+
+Note that `run()` resolves when the task **starts**, not when it finishes.
+`await promisePool.run(...)` therefore applies backpressure: it pauses the caller only while the pool is full.
+
+## Usage
+
+### Getting a task's return value
+
+Use `runAndWaitForReturnValue()` when you need the task's result (or its error):
+
+```ts
+const promisePool = new PromisePool(5);
+
+const results = await Promise.all(
+  urls.map((url) => promisePool.runAndWaitForReturnValue(async () => (await fetch(url)).json()))
+);
+```
+
+### Waiting for all running tasks
+
+```ts
+// Waits for all currently running tasks; rejects if any of them fails.
+await promisePool.promiseAll();
+
+// Waits for all currently running tasks and collects each outcome.
+const outcomes = await promisePool.promiseAllSettled();
+```
+
+### Adjusting concurrency at runtime
+
+```ts
+const promisePool = new PromisePool(10);
+promisePool.concurrency = 2; // Running tasks continue; new tasks respect the new limit.
+promisePool.concurrency = 20; // Queued tasks start immediately up to the new limit.
+```
+
+## API
+
+### `new PromisePool<T>(concurrency = 10)`
+
+Creates a pool that runs at most `concurrency` tasks concurrently.
+
+### Methods
+
+| Method                                | Returns                             | Description                                                                                          |
+| ------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
+| `run(startPromise)`                    | `Promise<void>`                     | Runs the task when the pool has capacity. Resolves once the task has started.                        |
+| `runAndWaitForReturnValue(startPromise)` | `Promise<R>`                        | Like `run()`, but resolves with the task's return value (and rejects if the task throws).            |
+| `promiseAll()`                         | `Promise<T[]>`                      | `Promise.all()` over the currently running tasks.                                                    |
+| `promiseAllSettled()`                  | `Promise<PromiseSettledResult<T>[]>` | `Promise.allSettled()` over the currently running tasks.                                             |
+
+### Properties
+
+| Property              | Type     | Description                                                                     |
+| --------------------- | -------- | ------------------------------------------------------------------------------- |
+| `concurrency`         | `number` | The maximum number of concurrent tasks. Writable; increasing it wakes queued tasks. |
+| `workingPromiseCount` | `number` | The number of currently running tasks.                                          |
+| `queuedPromiseCount`  | `number` | The number of tasks that have been submitted but not yet finished.               |
+
+### Error handling
+
+A rejection from a task passed to `run()` is not reported through `run()`'s returned promise (which only signals that the task started).
+Use `runAndWaitForReturnValue()` to receive rejections directly, or `promiseAllSettled()` to collect them in bulk.
+
+## License
+
+Apache License 2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE).

--- a/README.md
+++ b/README.md
@@ -107,20 +107,20 @@ Creates a pool that runs at most `concurrency` tasks concurrently.
 
 ### Methods
 
-| Method                                | Returns                             | Description                                                                                          |
-| ------------------------------------- | ----------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `run(startPromise)`                    | `Promise<void>`                     | Runs the task when the pool has capacity. Resolves once the task has started.                        |
-| `runAndWaitForReturnValue(startPromise)` | `Promise<R>`                        | Like `run()`, but resolves with the task's return value (and rejects if the task throws).            |
-| `promiseAll()`                         | `Promise<T[]>`                      | `Promise.all()` over the currently running tasks.                                                    |
-| `promiseAllSettled()`                  | `Promise<PromiseSettledResult<T>[]>` | `Promise.allSettled()` over the currently running tasks.                                             |
+| Method                                   | Returns                              | Description                                                                               |
+| ---------------------------------------- | ------------------------------------ | ----------------------------------------------------------------------------------------- |
+| `run(startPromise)`                      | `Promise<void>`                      | Runs the task when the pool has capacity. Resolves once the task has started.             |
+| `runAndWaitForReturnValue(startPromise)` | `Promise<R>`                         | Like `run()`, but resolves with the task's return value (and rejects if the task throws). |
+| `promiseAll()`                           | `Promise<T[]>`                       | `Promise.all()` over the currently running tasks.                                         |
+| `promiseAllSettled()`                    | `Promise<PromiseSettledResult<T>[]>` | `Promise.allSettled()` over the currently running tasks.                                  |
 
 ### Properties
 
-| Property              | Type     | Description                                                                     |
-| --------------------- | -------- | ------------------------------------------------------------------------------- |
+| Property              | Type     | Description                                                                         |
+| --------------------- | -------- | ----------------------------------------------------------------------------------- |
 | `concurrency`         | `number` | The maximum number of concurrent tasks. Writable; increasing it wakes queued tasks. |
-| `workingPromiseCount` | `number` | The number of currently running tasks.                                          |
-| `queuedPromiseCount`  | `number` | The number of tasks that have been submitted but not yet finished.               |
+| `workingPromiseCount` | `number` | The number of currently running tasks.                                              |
+| `queuedPromiseCount`  | `number` | The number of tasks that have been submitted but not yet finished.                  |
 
 ### Error handling
 


### PR DESCRIPTION
## Customer Summary

- The README now reads like a polished OSS project page: badges, a feature list, installation instructions, a quick start, usage recipes, and a full API reference.
- The quick-start example is now copy-paste runnable; the previous example imported a `sleep` helper that the package does not actually export.
- New sections explain non-obvious semantics, such as `run()` resolving when a task starts (not finishes) and how to observe task errors safely.

## Technical Summary

- README-only change; no code, configuration, or dependency changes.
- Added npm version and license badges alongside the existing Test and semantic-release badges.
- Documented the full public API of `PromisePool` (methods and properties) in reference tables, plus usage examples for `runAndWaitForReturnValue()`, `promiseAll()`/`promiseAllSettled()`, and runtime `concurrency` adjustment.
- The error-handling section explains that `promiseAll()`/`promiseAllSettled()` cover only tasks still running at call time (settled tasks are removed from the pool), that an unobserved rejection from a `run()` task becomes an unhandled promise rejection, and that `Promise.allSettled(tasks.map((task) => promisePool.runAndWaitForReturnValue(task)))` is the reliable pattern for collecting outcomes. This behavior was confirmed with a runtime reproduction during review.

## Why

- The previous README covered only `run()` with a single example, leaving most of the public API undocumented, and its example code did not compile against the actual exports.
- A clearer README lowers the barrier for new users and reduces confusion around `run()`'s start-vs-finish resolution semantics and error observation, which can otherwise crash Node.js processes via unhandled rejections.

## Testing

- Verified the documented API against `src/index.ts` and `test/index.test.ts` (e.g. confirmed `sleep` is not exported and that `run()` resolves on task start).
- Reproduced with a focused script that a rejected `run()` task is removed from the pool on settlement and a later `promiseAllSettled()` returns `[]`, confirming the documented error-handling guidance.
- Documentation-only change; no tests affected.
