### PR TITLE
test: move the unit test under test/unit/

### DIFF
--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from 'vitest';
 
-import { PromisePool } from '../src/index.js';
+import { PromisePool } from '../../src/index.js';
 
 test('run three heavy tasks', async () => {
   const env = new TestEnvironment(2);


### PR DESCRIPTION
## Customer Summary

- Moves the test file into `test/unit/`. No product or API change.

## Technical Summary

- `test/index.test.ts` → `test/unit/index.test.ts`, with its relative import to `src/` updated.

## Why

`@willbooster/wb` 19.1.0 enforces a test layout: test files may live only under `test/unit/`, `test/e2e/`, and `test/debug/`, and `test/` itself may contain only those plus `helpers/` and `fixtures/`. The check runs in `wb lint` and `wb verify`.

This repository pins wb 15.4.0, so nothing fails today — wb 15 runs `vitest run test` and all 13 tests execute. But wb 19 narrows the unit target to `test/unit/`, so on the eventual upgrade the current layout would both fail the check and run zero tests. Doing the move now keeps that upgrade PR green.

## Testing

- `bun verify` passes.
- `bun run test` passes: 13 tests, 1 file — the same count as on `main` before the move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
