### PR TITLE
chore: remove retired reusable-workflow callers

### DIFF
--- a/.github/workflows/wbfy-merge-test.yml
+++ b/.github/workflows/wbfy-merge-test.yml
@@ -1,8 +1,0 @@
-name: Test Merge
-on:
-  workflow_dispatch:
-jobs:
-  test-merge:
-    uses: WillBooster/reusable-workflows/.github/workflows/wbfy-merge.yml@main
-    secrets:
-      GH_TOKEN: ${{ secrets.PUBLIC_GH_BOT_PAT }}


### PR DESCRIPTION
The App-based autofix flow, the nightly self-applying wbfy caller, and autofix.ci were retired org-wide (WillBooster/reusable-workflows#484, WillBooster/shared#1110), so these caller workflows now reference workflows that no longer exist. Removing them keeps CI from failing at workflow resolution.

Fixes are still reported: the test job fails with the diff for a developer or agent to apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)